### PR TITLE
added support for GCODE commands:

### DIFF
--- a/firmwares/Eclipse/STM32f103r/src/Command.c
+++ b/firmwares/Eclipse/STM32f103r/src/Command.c
@@ -2706,6 +2706,67 @@ void Processing_command(void)
                 Add_Message(TEMPERATURE_INFO);
             break;
 #endif
+
+            case 201: //set max acceleration per axis (XYZE)
+            	for(u8 i=0;i<NUM_AXIS;i++)
+            	{
+            		if(Command_is(Coordinate_Axias[i],&ch_point))
+            		{
+            			Setting.max_acceleration[i] = Command_value_float(ch_point);
+            		}
+            	}
+            	break;
+
+            case 203: //max feed rate per axis (XYZE)
+            	for(u8 i=0;i<NUM_AXIS;i++)
+            	{
+            		if(Command_is(Coordinate_Axias[i],&ch_point))
+            		{
+            			Setting.max_feedrate[i] = Command_value_float(ch_point);
+            		}
+            	}
+            	break;
+
+            case 204: //set default acceleration
+            	if(Command_is('P',&ch_point)) //printing acceleration
+            	{
+            		Setting.acceleration = Command_value_float(ch_point);
+            	}
+            	if(Command_is('R',&ch_point)) //retract acceleration
+            	{
+            		Setting.retract_acceleration = Command_value_float(ch_point);
+            	}
+            	if(Command_is('T',&ch_point)) //travel acceleration (not yet implemented)
+            	{
+            		Setting.travel_acceleration = Command_value_float(ch_point);
+            	}
+
+            case 205:  //set advanced settings
+            	if(Command_is('S',&ch_point)) //min travel speed while printing
+            	{
+            		Setting.min_feedrate = Command_value_float(ch_point);
+            	}
+            	if(Command_is('T',&ch_point)) //min travel speed during travel
+            	{
+            		Setting.min_travel_feedrate = Command_value_float(ch_point);
+            	}
+            	if(Command_is('B',&ch_point)) //min travel speed during travel
+            	{
+            		Setting.min_segment_time = Command_value_float(ch_point);
+            	}
+            	if(Command_is(Coordinate_Axias[i],&ch_point)) //jerk per axis (XYZE)
+            	{
+            		if(i==0)
+            			Setting.max_x_jerk = Command_value_float(ch_point);
+            		else if(i==1)
+            			Setting.max_y_jerk = Command_value_float(ch_point);
+            		else if(i==2)
+            			Setting.max_z_jerk = Command_value_float(ch_point);
+            		else if(i==3)
+            			Setting.max_e_jerk = Command_value_float(ch_point);
+            	}
+            break;
+
             case 220:
                 if(Command_is('S',&ch_point))
                 {

--- a/firmwares/Eclipse/STM32f103r/src/setting.h
+++ b/firmwares/Eclipse/STM32f103r/src/setting.h
@@ -64,6 +64,7 @@ typedef struct
   u8   endstop_status[6];                          //Limit switch enable status
   float retract_acceleration;                      //retract  Acceleration
   float acceleration;					//Acceleration
+  float travel_acceleration;			//Travel acceleration
   u32 axis_steps_per_sqr_second[4];      //XYZE  number of moves
   u8 min_travel_feedrate;                            //Airspeed minimum speed
   u8 min_feedrate;	                                //minimum  print speed


### PR DESCRIPTION
I have added in the missing support for GCODEs M201, M203, M204, and M205:
 * M201 - Set max acceleration in units/s^2 for print moves (M201 X1000 Y1000 Z1000 E10)
 * M203 - Set maximum feed rate that your machine can sustain (M203 X200 Y200 Z300 E100) in mm/sec
 * M204 - Set default acceleration: P for Printing moves, R for Retract only (no X, Y, Z) moves, and T for Travel (non printing) moves (Not yet implemented)  in mm/sec^2 (ex. M204 P800 T3000 R9000)
 * M205 -  advanced settings:  S=printing minimum feed rate, T=travel minimum feed rate,  B=minimum segment time,  X= maximum x jerk, Y= maximum y jerk, Z=maximum Z jerk, E=maximum E jerk


I added variable travel_acceleration to setting.h but it is not yet being used in motion planning.  This setting would affect acceleration on X and Y axis (possibly Z) for travel only moves (when not extruding).  We will need to decide how this is handled, as many slicers only use G1 command for all moves vs. G1 for print moves and G0 for travel.  This may not be necessary at all.
